### PR TITLE
fix: retry transient GitHub API failures in Get Release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,13 +66,14 @@ runs:
       id: get-release
       uses: actions/github-script@v9
       with:
+        # Retry transient network and 5xx failures reaching the GitHub API.
+        retries: 3
         script: |
           const tag = '${{ inputs.tag }}';
           const [owner, repo] = '${{ inputs.repository }}'.split('/');
           const release = await github.rest.repos.getReleaseByTag({owner, repo, tag});
           if (!release || !release.data.body) {
-              console.error('Invalid release');
-              return;
+              throw new Error(`No release body found for tag ${tag}`);
           }
           console.log(release.data.body);
           return {


### PR DESCRIPTION
The `Get Release` step calls `getReleaseByTag` through `actions/github-script`, which defaults to `retries: 0`. A transient network failure reaching the GitHub API (`fetch failed`, HTTP 500) killed the release notes step in the client Release workflow, even though the release existed.

Enabling `retries: 3` lets the 5xx and fetch-failure class self-heal. The default exempt codes (400/401/403/404/422) are unchanged, so a genuinely missing release still fails fast.

The invalid-release path now throws with a clear message instead of returning an empty output, which previously surfaced downstream as a confusing `fromJSON` template error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retries for transient network and server errors when retrieving a release by tag.
  * Improved failure handling when a release is missing or has no body—now surfaces a clear error message instead of silently logging and stopping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->