### PR TITLE
test: mock Confluence API in CI instead of live instance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,15 +10,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Start mock Confluence server
+        run: |
+          python test/mock_confluence_server.py --port 8080 --space-key TEST --page-id 123456 &
+          for i in $(seq 1 10); do
+            if curl -sf http://localhost:8080/wiki/rest/api/space/TEST >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Mock server did not start" && exit 1
+
       - name: Run action
         id: run_action
         uses: ./
         with:
-          email: ${{ secrets.CONFLUENCE_EMAIL }}
-          api_token: ${{ secrets.CONFLUENCE_API_TOKEN }}
-          host: solidstatenetworks.jira.com
-          space_key: ${{ secrets.CONFLUENCE_SPACE_KEY }}
-          page_id: ${{ secrets.CONFLUENCE_PAGE_ID }}
+          email: test@test.com
+          api_token: fake-token
+          host: http://localhost:8080
+          space_key: TEST
+          page_id: 123456
           title: Test Change Log
           tag: 1.1.0
           repository: snxd/jira-version-action

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
     type: string
   host:
-    description: Confluence host name
+    description: Confluence host name. May include a scheme; defaults to https.
     required: true
     type: string
   space_key:
@@ -47,6 +47,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve Confluence base URL
+      shell: bash
+      run: |
+        # Prepend https when the host omits a scheme so bare hostnames keep working.
+        host='${{ inputs.host }}'
+        case "$host" in
+          http://*|https://*) ;;
+          *) host="https://$host" ;;
+        esac
+        echo "confluenceBaseUrl=$host" >> $GITHUB_ENV
+
     - name: Install markdown to HTML converter
       shell: bash
       run: sudo apt-get install -y pandoc
@@ -73,7 +84,7 @@ runs:
       shell: bash
       run: |
         response=$(curl --request GET \
-            --url "https://${{ inputs.host }}/wiki/rest/api/space/${{ inputs.space_key }}" \
+            --url "${{ env.confluenceBaseUrl }}/wiki/rest/api/space/${{ inputs.space_key }}" \
             --user '${{ inputs.email }}:${{ inputs.api_token }}' \
             --header 'Accept: application/json')
         echo "Response: $response"
@@ -88,7 +99,7 @@ runs:
       shell: bash
       run: |
         response=$(curl --request GET \
-            --url 'https://${{ inputs.host }}/wiki/api/v2/pages/${{ inputs.page_id }}' \
+            --url "${{ env.confluenceBaseUrl }}/wiki/api/v2/pages/${{ inputs.page_id }}" \
             --user '${{ inputs.email }}:${{ inputs.api_token }}' \
             --header 'Accept: application/json')
         echo "Response: $response"
@@ -136,7 +147,7 @@ runs:
         html_content=$(<release_notes.html)
 
         response=$(curl --request GET \
-            --url 'https://${{ inputs.host }}/wiki/rest/api/content/${{ inputs.page_id }}?expand=body.storage' \
+            --url "${{ env.confluenceBaseUrl }}/wiki/rest/api/content/${{ inputs.page_id }}?expand=body.storage" \
             --user '${{ inputs.email }}:${{ inputs.api_token }}' \
             --header 'Accept: application/json')
         echo "Response: $response"
@@ -169,7 +180,7 @@ runs:
 
         echo "Payload: $(cat payload.json)"
         response=$(curl --request PUT \
-            --url 'https://${{ inputs.host }}/wiki/api/v2/pages/${{ inputs.page_id }}' \
+            --url "${{ env.confluenceBaseUrl }}/wiki/api/v2/pages/${{ inputs.page_id }}" \
             --user '${{ inputs.email }}:${{ inputs.api_token }}' \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \

--- a/test/mock_confluence_server.py
+++ b/test/mock_confluence_server.py
@@ -1,0 +1,134 @@
+"""
+A lightweight mock Confluence REST API server for testing the GitHub action
+end-to-end without a real Confluence instance.
+
+Implements just enough of the Confluence API to support:
+  - GET /wiki/rest/api/space/{key}                     (get space id)
+  - GET /wiki/api/v2/pages/{id}                         (get current version)
+  - GET /wiki/rest/api/content/{id}?expand=body.storage (get existing content)
+  - PUT /wiki/api/v2/pages/{id}                         (update the page)
+"""
+
+import argparse
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SPACE_KEY = "TEST"
+SPACE_ID = "393217"
+PAGE_ID = "123456"
+
+# In-memory page store keyed by page id
+pages = {
+    PAGE_ID: {
+        "id": PAGE_ID,
+        "status": "current",
+        "title": "Test Change Log",
+        "spaceId": SPACE_ID,
+        "version": {"number": 1},
+        "body": {"storage": {"value": "<p>Existing content</p>", "representation": "storage"}},
+    }
+}
+
+
+class ConfluenceHandler(BaseHTTPRequestHandler):
+    def _send_json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_error(self, status, message):
+        self._send_json({"statusCode": status, "message": message}, status)
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            return json.loads(self.rfile.read(length))
+        return {}
+
+    def do_GET(self):
+        parts = self.path.split("?")[0].rstrip("/").split("/")
+
+        # GET /wiki/rest/api/space/{key}
+        if self.path.startswith("/wiki/rest/api/space/"):
+            key = parts[-1]
+            if key == SPACE_KEY:
+                self._send_json({"id": SPACE_ID, "key": SPACE_KEY})
+            else:
+                self._send_error(404, f"No space found with key : {key}")
+            return
+
+        # GET /wiki/rest/api/content/{id}?expand=body.storage
+        if self.path.startswith("/wiki/rest/api/content/"):
+            page = pages.get(parts[-1])
+            if page:
+                self._send_json({"id": page["id"], "body": page["body"]})
+            else:
+                self._send_error(404, "Page not found")
+            return
+
+        # GET /wiki/api/v2/pages/{id}
+        if self.path.startswith("/wiki/api/v2/pages/"):
+            page = pages.get(parts[-1])
+            if page:
+                self._send_json(page)
+            else:
+                self._send_error(404, "Page not found")
+            return
+
+        self._send_error(404, "Not found")
+
+    def do_PUT(self):
+        # PUT /wiki/api/v2/pages/{id}
+        if self.path.startswith("/wiki/api/v2/pages/"):
+            page_id = self.path.rstrip("/").split("/")[-1]
+            page = pages.get(page_id)
+            if not page:
+                self._send_error(404, "Page not found")
+                return
+
+            data = self._read_body()
+            page["version"]["number"] = data.get("version", {}).get("number", page["version"]["number"])
+            page["title"] = data.get("title", page["title"])
+            page["status"] = data.get("status", page["status"])
+            if "body" in data:
+                page["body"]["storage"]["value"] = data["body"].get("value", "")
+            self._send_json(page)
+            return
+
+        self._send_error(404, "Not found")
+
+    # Suppress request logging to keep CI output clean
+    def log_message(self, format, *args):
+        print(f"[mock-confluence] {args[0]}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mock Confluence API server")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--space-key", default="TEST")
+    parser.add_argument("--page-id", default="123456")
+    args = parser.parse_args()
+
+    global SPACE_KEY, PAGE_ID
+    SPACE_KEY = args.space_key
+    PAGE_ID = args.page_id
+    pages[PAGE_ID] = pages.pop(next(iter(pages)))
+    pages[PAGE_ID]["id"] = PAGE_ID
+
+    server = HTTPServer(("0.0.0.0", args.port), ConfluenceHandler)
+    print(f"Mock Confluence server listening on port {args.port} (space: {SPACE_KEY}, page: {PAGE_ID})")
+    sys.stdout.flush()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The Test workflow ran the whole action against a real Confluence space on `solidstatenetworks.jira.com` using repo secrets. It started failing when that space was removed, returning `404 No space found with key` at the Get Space ID step, unrelated to any code change.

This adds an in-memory mock Confluence server (`test/mock_confluence_server.py`) covering the four endpoints the action calls, mirroring the mock pattern already used in `jira-version-action`. The workflow starts it on localhost and runs the action with fake credentials, so the test no longer depends on live infrastructure or secrets.

The action hardcoded `https://` in its curl URLs, so `action.yml` now normalizes the host: a bare hostname still defaults to `https`, but a host that includes a scheme is left as-is, letting the workflow target `http://localhost:8080`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Confluence host settings now support full URLs, including custom schemes.
  * Bare hostnames automatically use HTTPS by default.
  * All Confluence operations consistently use the configured host format.

* **Bug Fixes**
  * Improved compatibility when connecting to Confluence instances with non-default URL schemes.

* **Tests**
  * Added local end-to-end testing with a mock Confluence service, reducing reliance on external environments and credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->